### PR TITLE
Correct path of copy icon

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -117,7 +117,7 @@ body:not(.theme-snap) .copyablelink.enabled button {
     left: calc(50% - .5em);
     filter: brightness(100);
     -webkit-filter: brightness(100);
-    background: url(/theme/image.php/clean/core/1460987426/e/copy) no-repeat center center;
+    background: url([[pix:core|t/copy]]) no-repeat center center;
     background-size: 100%;
 }
 


### PR DESCRIPTION
The path for the copy icon was
    background: url(/theme/image.php/clean/core/1460987426/e/copy) no-repeat center center;
which doesn't work with all themes.
I've changed it to 
    background: url([[pix:core|t/copy]]) no-repeat center center;
so that it matches other icon paths in this same file.