### PR TITLE
Issue #10: Added proxy settings for Curl and soap requests

### DIFF
--- a/classes/rest/api.php
+++ b/classes/rest/api.php
@@ -292,6 +292,29 @@ class api {
         if (!empty($headers)) {
             curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         }
+        // Add moodle proxy curlopts.
+        if (!empty($CFG->proxyhost)) {
+            if (empty($CFG->proxyport)) {
+                $proxyhost = $CFG->proxyhost;
+            } else {
+                $proxyhost = $CFG->proxyhost.':'.$CFG->proxyport;
+            }
+            if (!empty($CFG->proxyuser) and !empty($CFG->proxypassword)) {
+                $proxyauth = $CFG->proxyuser.':'.$CFG->proxypassword;
+                curl_setopt($ch, CURLOPT_PROXYAUTH, CURLAUTH_BASIC | CURLAUTH_NTLM);
+                curl_setopt($ch, CURLOPT_PROXYUSERPWD, $proxyauth);
+            }
+            if (!empty($CFG->proxytype)) {
+                if ($CFG->proxytype == 'SOCKS5') {
+                    $proxytype = CURLPROXY_SOCKS5;
+                } else {
+                    $proxytype = CURLPROXY_HTTP;
+                    curl_setopt($ch, CURLOPT_HTTPPROXYTUNNEL, false);
+                }
+                curl_setopt($ch, CURLOPT_PROXYTYPE, $proxytype);
+            }
+            curl_setopt($ch, CURLOPT_PROXY, $proxyhost);
+        }
         $jsonstr = curl_exec($ch);
         $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         $this->logger->info('response', ['httpcode' => $httpcode]);


### PR DESCRIPTION
This PR adds the ability for curl calls in the REST API, and the SOAP calls in the SOAP API to use Moodle's configured proxy settings.

Closes #10 