### PR TITLE
Issue #32: Updated logging function declarations

### DIFF
--- a/classes/logging/loggerbase.php
+++ b/classes/logging/loggerbase.php
@@ -55,9 +55,9 @@ abstract class loggerbase implements LoggerInterface {
      *
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public function emergency($message, array $context = []) {
+    public function emergency($message, array $context = []): void {
         // Only log if range is light or greater (Emergency|Alert|Critical).
         if ($this->logrange >= constants::RANGE_LIGHT) {
             $this->log(LogLevel::EMERGENCY, $message, $context);
@@ -72,9 +72,9 @@ abstract class loggerbase implements LoggerInterface {
      *
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public function alert($message, array $context = []) {
+    public function alert($message, array $context = []): void {
         // Only log if range is light or greater (Emergency|Alert|Critical).
         if ($this->logrange >= constants::RANGE_LIGHT) {
             $this->log(LogLevel::ALERT, $message, $context);
@@ -88,9 +88,9 @@ abstract class loggerbase implements LoggerInterface {
      *
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public function critical($message, array $context = []) {
+    public function critical($message, array $context = []): void {
         // Only log if range is light or greater (Emergency|Alert|Critical).
         if ($this->logrange >= constants::RANGE_LIGHT) {
             $this->log(LogLevel::CRITICAL, $message, $context);
@@ -103,9 +103,9 @@ abstract class loggerbase implements LoggerInterface {
      *
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public function error($message, array $context = []) {
+    public function error($message, array $context = []): void {
         // Only log if range is medium or greater (Emergency|Alert|Critical|Error|Warning).
         if ($this->logrange >= constants::RANGE_MEDIUM) {
             $this->log(LogLevel::ERROR, $message, $context);
@@ -120,9 +120,9 @@ abstract class loggerbase implements LoggerInterface {
      *
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public function warning($message, array $context = []) {
+    public function warning($message, array $context = []): void {
         // Only log if range is medium (Emergency|Alert|Critical|Error|Warning).
         if ($this->logrange >= constants::RANGE_MEDIUM) {
             $this->log(LogLevel::WARNING, $message, $context);
@@ -134,9 +134,9 @@ abstract class loggerbase implements LoggerInterface {
      *
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public function notice($message, array $context = []) {
+    public function notice($message, array $context = []): void{
         // Only log if range is all - every possible type of log.
         if ($this->logrange >= constants::RANGE_ALL) {
             $this->log(LogLevel::NOTICE, $message, $context);
@@ -150,9 +150,9 @@ abstract class loggerbase implements LoggerInterface {
      *
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public function info($message, array $context = []) {
+    public function info($message, array $context = []): void {
         // Only log if range is all - every possible type of log.
         if ($this->logrange >= constants::RANGE_ALL) {
             $this->log(LogLevel::INFO, $message, $context);
@@ -164,9 +164,9 @@ abstract class loggerbase implements LoggerInterface {
      *
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public function debug($message, array $context = []) {
+    public function debug($message, array $context = []): void {
         // Only log if range is all - every possible type of log.
         if ($this->logrange >= constants::RANGE_ALL) {
             $this->log(LogLevel::DEBUG, $message, $context);
@@ -179,8 +179,8 @@ abstract class loggerbase implements LoggerInterface {
      * @param mixed $level
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    abstract public function log($level, $message, array $context = []);
+    abstract public function log($level, $message, array $context = []): void;
 
 }

--- a/classes/logging/loggerdb.php
+++ b/classes/logging/loggerdb.php
@@ -36,9 +36,9 @@ class loggerdb extends loggerbase {
      * @param mixed $level
      * @param string $message
      * @param array $context
-     * @return null
+     * @return void
      */
-    public function log($level, $message, array $context = []) {
+    public function log($level, $message, array $context = []): void {
         global $DB;
         $data = '';
         foreach ($context as $key => $val) {
@@ -52,6 +52,6 @@ class loggerdb extends loggerbase {
 
         $record = (object) ['time' => time(), 'level' => $level, 'message' => $message, 'data' => $data];
 
-        return $DB->insert_record('collaborate_log', $record);
+        $DB->insert_record('collaborate_log', $record);
     }
 }


### PR DESCRIPTION
Closes Issue #32.

I've added the proper return types for functions in `logging/loggerbase.php` to fix the fatal errors occurring in PHPUnit tests. 

### Environment Details
* PHP 8.1
* MOODLE 4.5
* Postgres 16.0

Branch that has the issue:
* `MOODLE_405_STABLE`

**How to recreate the issue?**
1. Deploy a local Moodle 4.5 instance (with this plugin installed on branch `MOODLE_405_STABLE`)
2. Initialize PHPUnit testing environment
3. Run `vendor/bin/phpunit` -> the error only appears when running the full list of unit tests. Running `vendor/bin/phpunit --testsuite mod_collaborate_testsuite` yields no errors.

**Actual Output**
```
Moodle 4.5.5 (Build: 20250609)
Php: 8.1.2.1.2.22, pgsql: 16.9 (Debian 16.9-1.pgdg120+1), OS: Linux 6.8.0-1021-aws x86_64
PHPUnit 9.6.18 by Sebastian Bergmann and contributors.

...........................................................    59 / 31274 (  0%)
...........................................................   118 / 31274 (  0%)
..........................................SS...............   177 / 31274 (  0%)
...........................................................   236 / 31274 (  0%)
...........................................................   295 / 31274 (  0%)
<shortened test output>
........................................................... 12036 / 31274 ( 38%)
......................................................
Fatal error: Declaration of mod_collaborate\logging\loggerdb::log($level, $message, array $context = []) must be compatible with mod_collaborate\logging\loggerbase::log($level, $message, array $context = []): void in /var/www/site/mod/collaborate/classes/logging/loggerdb.php on line 41
PHP Fatal error:  Declaration of mod_collaborate\logging\loggerdb::log($level, $message, array $context = []) must be compatible with mod_collaborate\logging\loggerbase::log($level, $message, array $context = []): void in /var/www/site/mod/collaborate/classes/logging/loggerdb.php on line 41
```
Checkout to my branch, and you should see no PHP Fatal errors related to `mod_collaborate` when running `vendor/bin/phpunit`.